### PR TITLE
Have updater ignore failed builds

### DIFF
--- a/scripts/webapp.py
+++ b/scripts/webapp.py
@@ -35,7 +35,7 @@ def server(environ, start_response):
     return iter([data])
 
 def update_styles(environ):
-    if environ["response_status"][0:3] != "200" || environ["build_status"] != 0:
+    if environ["response_status"][0:3] != "200" or environ["build_status"] != 0:
         return
 
     try:

--- a/scripts/webapp.py
+++ b/scripts/webapp.py
@@ -16,12 +16,14 @@ def server(environ, start_response):
     request_body = environ['wsgi.input'].read(request_body_size)
     if request_body:
         try:
-            payload = parse_qs(request_body)["payload"][0]
-            environ["commit_hash"] = json.loads(payload)["commit"]
+            payload = json.loads(parse_qs(request_body)["payload"][0])
+            environ["commit_hash"] = payload["commit"]
+            environ["build_status"] = payload["status"]
         except ValueError:
             status = "400 Bad Request"
     else:
         environ["commit_hash"] = "HEAD"
+        environ["build_status"] = 0
 
     data = "\n"
     environ["response_status"] = status
@@ -33,7 +35,7 @@ def server(environ, start_response):
     return iter([data])
 
 def update_styles(environ):
-    if environ["response_status"][0:3] != "200":
+    if environ["response_status"][0:3] != "200" || environ["build_status"] != 0:
         return
 
     try:


### PR DESCRIPTION
In order to enable the CSL bot to respond to failed builds, we need to add a new webhook to the styles repository. In Travis CI's [documentation](http://docs.travis-ci.com/user/notifications/#Webhook-notification) it looks like the setting for `on_failure` can only be applied to all webhooks equally, so we should ensure that the distribution updater ignores failed builds. Successful builds set `"success": 0` in the payload, so I simply added a test for this.

@dstillman @rmzelle could you review this and/or let me know if there is an easy way to test this, to make sure it works?
